### PR TITLE
Fix poll timeout delay - add config parameter for this

### DIFF
--- a/FluentFTP.GnuTLS/GnuConfig.cs
+++ b/FluentFTP.GnuTLS/GnuConfig.cs
@@ -31,9 +31,16 @@ namespace FluentFTP.GnuTLS {
 		public IList<GnuAdvanced> AdvancedOptions { get; set; } = null;
 
 		/// <summary>
-		/// How long to wait for a handshake before giving up, in MS. Set to zero to disable.
+		/// How long to wait for a handshake before giving up, in milliseconds.
+		/// Set to zero to disable.
 		/// </summary>
 		public int HandshakeTimeout { get; set; } = 5000;
+
+		/// <summary>
+		/// How long to wait for a connectivity socket poll, in milliseconds.
+		/// Set to zero to disable.
+		/// </summary>
+		public int PollTimeout { get; set; } = 500;
 
 		/// <summary>
 		/// Select the maximum verbosity of the GnuTLS messages which are logged with serverity "verbose".

--- a/FluentFTP.GnuTLS/GnuTlsStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream.cs
@@ -49,6 +49,7 @@ namespace FluentFTP.GnuTLS {
 				isControl ? null : (controlConnStream as GnuTlsStream).BaseStream,
 				priority,
 				config.HandshakeTimeout,
+				config.PollTimeout,
 				fluentFtpLog,
 				config.LogLevel,
 				config.LogMessages,

--- a/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
@@ -44,7 +44,10 @@ namespace FluentFTP.GnuTLS {
 		private string hostname;
 
 		// The Handshake Timeout to be honored on handshake
-		private int timeout;
+		private int htimeout;
+
+		// The Poll Timeout to use for connectivity test
+		private int ptimeout;
 
 		//
 		// For our own inside use
@@ -93,6 +96,7 @@ namespace FluentFTP.GnuTLS {
 			GnuTlsInternalStream streamToResume,
 			string priorityString,
 			int handshakeTimeout,
+			int pollTimeout,
 			GnuStreamLogCBFunc elog,
 			int logMaxLevel,
 			GnuMessage logDebugInformationMessages,
@@ -102,7 +106,8 @@ namespace FluentFTP.GnuTLS {
 			alpn = alpnString;
 			priority = priorityString;
 			hostname = targetHostString;
-			timeout = handshakeTimeout;
+			htimeout = handshakeTimeout;
+			ptimeout = pollTimeout;
 
 			if (ctorCount < 1) {
 


### PR DESCRIPTION
Make this value configurable, and also the ability to disable this check completely.
```cs
		/// <summary>
		/// How long to wait for a connectivity socket poll, in milliseconds.
		/// Set to zero to disable.
		/// </summary>
		public int PollTimeout { get; set; } = 500;
```
