### PR TITLE
Fix GetCurrentMethod output value

### DIFF
--- a/FluentFTP.GnuTLS/Core/GnuUtils.cs
+++ b/FluentFTP.GnuTLS/Core/GnuUtils.cs
@@ -1,17 +1,12 @@
-﻿using System.Diagnostics;
-using System.Linq;
+﻿using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace FluentFTP.GnuTLS.Core {
 	internal class GnuUtils {
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
-		public static string GetCurrentMethod() {
-
-			var st = new StackTrace();
-			var sf = st.GetFrame(1);
-
-			return "*" + sf.GetMethod().Name + "(...)";
+		public static string GetCurrentMethod([CallerMemberName] string memberName = "") {
+			return "*" + memberName + "(...)";
 		}
 
 		public static int Check(string methodName, int result, params int[] resultsAllowed) {


### PR DESCRIPTION
Interesting: Using the "examine call stack trace" method to determine the name of the current method will fail if building in "release" mode, because the compiler will in-line many sequences of code - **not only the `GetCurrentMethod` function itself, but also methods above it**, thereby mangling the expected positions on the internal stack trace.

It turns out, there is actually a compiler directive that solves this problem for the coder: At compile time, the caller is determined and placed in a parameter.

See: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.callermembernameattribute?view=net-7.0

This works across all targets.