### PR TITLE
Only attach GnuTLS logging AFTER lib validation

### DIFF
--- a/FluentFTP.GnuTLS/Core/Logging.cs
+++ b/FluentFTP.GnuTLS/Core/Logging.cs
@@ -92,7 +92,7 @@ namespace FluentFTP.GnuTLS.Core {
 		// Avoid garbage collection failure of this callback
 		private static GnuTlsLogCBFunc gnuTlsLogCBFunc = Log;
 
-		// Setup logging
+		// Setup logging overall
 		public static void InitLogging(GnuStreamLogCBFunc logCBFunc, int logMaxLevel, GnuMessage logDebugInformation, int logQueueMaxSize) {
 			logQueue = new Queue<string>();
 
@@ -101,6 +101,10 @@ namespace FluentFTP.GnuTLS.Core {
 			Logging.logDebugInformation = logDebugInformation;
 			Logging.logQueueMaxSize = logQueueMaxSize;
 
+		}
+
+		// Setup GnuTls logging to overall log
+		public static void AttachGnuTlsLogging() {
 			GnuTls.GnuTlsGlobalSetLogFunction(gnuTlsLogCBFunc);
 			GnuTls.GnuTlsGlobalSetLogLevel(99);
 		}

--- a/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
@@ -122,6 +122,8 @@ namespace FluentFTP.GnuTLS {
 
 				ValidateLibrary(true);
 
+				Logging.AttachGnuTlsLogging();
+
 				// GnuTlsStreams are organized as
 				// TLS 1.2:
 				// First one: Creates/Initializes the GnuTls infrastructure, cannot resume


### PR DESCRIPTION
The only way to get early log messages in case library validation later fails.