### PR TITLE
Do not use subfolder "Libs/" for DllImport file name

### DIFF
--- a/FluentFTP.GnuTLS/Core/GnuTls.cs
+++ b/FluentFTP.GnuTLS/Core/GnuTls.cs
@@ -11,21 +11,21 @@ namespace FluentFTP.GnuTLS.Core {
 			return Marshal.PtrToStringAnsi(gnutls_check_version(reqVersion));
 		}
 		// const char * gnutls_check_version (const char * req_version)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_check_version")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_check_version")]
 		private static extern IntPtr gnutls_check_version([In()][MarshalAs(UnmanagedType.LPStr)] string req_version);
 
 		public static void GnuTlsGlobalSetLogFunction(Logging.GnuTlsLogCBFunc logCBFunc) {
 			gnutls_global_set_log_function(logCBFunc);
 		}
 		// void gnutls_global_set_log_function (gnutls_log_func log_func)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_global_set_log_function")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_global_set_log_function")]
 		private static extern void gnutls_global_set_log_function([In()][MarshalAs(UnmanagedType.FunctionPtr)] Logging.GnuTlsLogCBFunc log_func);
 
 		public static void GnuTlsGlobalSetLogLevel(int level) {
 			gnutls_global_set_log_level(level);
 		}
 		// void gnutls_global_set_log_level (int level)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_global_set_log_level")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_global_set_log_level")]
 		private static extern void gnutls_global_set_log_level(int level);
 
 		public static int GnuTlsGlobalInit() {
@@ -35,7 +35,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, gnutls_global_init());
 		}
 		// int gnutls_global_init ()
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_global_init")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_global_init")]
 		private static extern int gnutls_global_init();
 
 		public static void GnuTlsGlobalDeInit() {
@@ -45,7 +45,7 @@ namespace FluentFTP.GnuTLS.Core {
 			gnutls_global_deinit();
 		}
 		// void gnutls_global_deinit ()
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_global_deinit")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_global_deinit")]
 		private static extern void gnutls_global_deinit();
 
 		// FREE WORKAROUND
@@ -64,9 +64,9 @@ namespace FluentFTP.GnuTLS.Core {
 
 		public static void GnuTlsFree(IntPtr ptr) {
 			if (GnuTlsInternalStream.hDLL == IntPtr.Zero) {
-				GnuTlsInternalStream.hDLL = LoadLibrary("Libs/libgnutls-30.dll");
+				GnuTlsInternalStream.hDLL = LoadLibrary("libgnutls-30.dll");
 				if (GnuTlsInternalStream.hDLL == IntPtr.Zero) {
-					throw new GnuTlsException("LoadLibrary for Libs/libgnutls-30.dll failed.");
+					throw new GnuTlsException("LoadLibrary for libgnutls-30.dll failed.");
 				}
 			}
 
@@ -77,7 +77,7 @@ namespace FluentFTP.GnuTLS.Core {
 			freeFunc(ptr);
 		}
 		// void gnutls_free(* ptr)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_free")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_free")]
 		public static extern void gnutls_free(IntPtr ptr);
 
 		//
@@ -87,11 +87,11 @@ namespace FluentFTP.GnuTLS.Core {
 		// G N U T L S API calls for session init / deinit
 
 		// int gnutls_init (gnutls_session_t * session, unsigned int flags)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_init")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_init")]
 		public static extern int gnutls_init(ref IntPtr session, InitFlagsT flags);
 
 		// void gnutls_deinit (gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_deinit")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_deinit")]
 		public static extern void gnutls_deinit(IntPtr session);
 
 		public static IntPtr GnuTlsSessionGetPtr(Session sess) {
@@ -101,7 +101,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_session_get_ptr(sess.ptr);
 		}
 		// IntPtr gnutls_session_get_ptr (gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_get_ptr")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_get_ptr")]
 		private static extern IntPtr gnutls_session_get_ptr(IntPtr session);
 
 		public static void GnuTlsSessionSetPtr(Session sess, IntPtr ptr) {
@@ -111,7 +111,7 @@ namespace FluentFTP.GnuTLS.Core {
 			gnutls_session_set_ptr(sess.ptr, ptr);
 		}
 		// void gnutls_session_set_ptr (gnutls_session_t session, void * ptr)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_set_ptr")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_set_ptr")]
 		private static extern void gnutls_session_set_ptr(IntPtr session, IntPtr ptr);
 
 
@@ -123,7 +123,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return;
 		}
 		// void gnutls_db_set_cache_expiration (gnutls_session_t session, int seconds)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_db_set_cache_expiration")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_db_set_cache_expiration")]
 		private static extern void gnutls_db_set_cache_expiration(IntPtr session, int seconds);
 
 		// Info
@@ -139,7 +139,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return desc;
 		}
 		// char* gnutls_session_get_desc(gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_get_desc")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_get_desc")]
 		private static extern IntPtr gnutls_session_get_desc(IntPtr session);
 
 		public static string GnuTlsProtocolGetName(ProtocolT version) {
@@ -152,7 +152,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return name;
 		}
 		// const char * gnutls_protocol_get_name (gnutls_protocol_t version)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_protocol_get_name")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_protocol_get_name")]
 		private static extern IntPtr gnutls_protocol_get_name(ProtocolT version);
 
 		public static ProtocolT GnuTlsProtocolGetVersion(Session sess) {
@@ -162,7 +162,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return (ProtocolT)GnuUtils.Check(gcm, (int)gnutls_protocol_get_version(sess.ptr));
 		}
 		// gnutls_protocol_t gnutls_protocol_get_version (gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_protocol_get_version")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_protocol_get_version")]
 		private static extern ProtocolT gnutls_protocol_get_version(IntPtr session);
 
 		public static int GnuTlsRecordGetMaxSize(Session sess) {
@@ -172,7 +172,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_record_get_max_size(sess.ptr);
 		}
 		// size_t gnutls_record_get_max_size (gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_record_get_max_size")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_record_get_max_size")]
 		private static extern int gnutls_record_get_max_size(IntPtr session);
 
 		public static AlertDescriptionT GnuTlsAlertGet(Session sess) {
@@ -181,14 +181,14 @@ namespace FluentFTP.GnuTLS.Core {
 
 			return gnutls_alert_get(sess.ptr);
 		}
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_alert_get")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_alert_get")]
 		private static extern AlertDescriptionT gnutls_alert_get(IntPtr session);
 
 		public static string GnuTlsAlertGetName(AlertDescriptionT alert) {
 			return Marshal.PtrToStringAnsi(gnutls_get_alert_name(alert));
 		}
 		// const char * gnutls_alert_get_name (gnutls_alert_description_t alert)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_get_alert_name")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_get_alert_name")]
 		private static extern IntPtr gnutls_get_alert_name(AlertDescriptionT alert);
 
 		public static bool GnuTlsErrorIsFatal(int error) {
@@ -198,7 +198,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_error_is_fatal(error);
 		}
 		// int gnutls_error_is_fatal (int error)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_error_is_fatal")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_error_is_fatal")]
 		private static extern bool gnutls_error_is_fatal(int error);
 
 		// Traffic
@@ -220,7 +220,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, result);
 		}
 		// int gnutls_handshake (gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_handshake")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_handshake")]
 		private static extern int gnutls_handshake(IntPtr session);
 
 		public static void GnuTlsHandshakeSetHookFunction(Session sess, uint htype, int when, GnuTlsInternalStream.GnuTlsHandshakeHookFunc handshakeHookFunc) {
@@ -230,7 +230,7 @@ namespace FluentFTP.GnuTLS.Core {
 			gnutls_handshake_set_hook_function(sess.ptr, htype, when, handshakeHookFunc);
 		}
 		// void gnutls_handshake_set_hook_function (gnutls_session_t session, unsigned int htype, int when, gnutls_handshake_hook_func func)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_handshake_set_hook_function")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_handshake_set_hook_function")]
 		private static extern void gnutls_handshake_set_hook_function(IntPtr session, uint htype, int when, [In()][MarshalAs(UnmanagedType.FunctionPtr)] GnuTlsInternalStream.GnuTlsHandshakeHookFunc func);
 
 		public static int GnuTlsBye(Session sess, CloseRequestT how) {
@@ -248,7 +248,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, result);
 		}
 		// int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_bye")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_bye")]
 		private static extern int gnutls_bye(IntPtr session, CloseRequestT how);
 
 		public static void GnuTlsHandshakeSetTimeout(Session sess, uint ms) {
@@ -258,7 +258,7 @@ namespace FluentFTP.GnuTLS.Core {
 			gnutls_handshake_set_timeout(sess.ptr, ms);
 		}
 		// void gnutls_handshake_set_timeout (gnutls_session_t session, unsigned int ms)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_handshake_set_timeout")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_handshake_set_timeout")]
 		private static extern void gnutls_handshake_set_timeout(IntPtr session, uint ms);
 
 		public static int GnuTlsRecordCheckPending(Session sess) {
@@ -268,7 +268,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_record_check_pending(sess.ptr);
 		}
 		// size_t gnutls_record_check_pending (gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_record_check_pending")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_record_check_pending")]
 		private static extern int gnutls_record_check_pending(IntPtr session);
 
 
@@ -281,7 +281,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, gnutls_set_default_priority(sess.ptr));
 		}
 		// int gnutls_set_default_priority (gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_set_default_priority")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_set_default_priority")]
 		private static extern int gnutls_set_default_priority(IntPtr session);
 
 		public static int GnuTlsPrioritySetDirect(Session sess, string priorities) {
@@ -292,7 +292,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, gnutls_priority_set_direct(sess.ptr, priorities, out errPos));
 		}
 		// int gnutls_priority_set_direct(gnutls_session_t session, const char* priorities, const char** err_pos)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_priority_set_direct")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_priority_set_direct")]
 		private static extern int gnutls_priority_set_direct(IntPtr session, [In()][MarshalAs(UnmanagedType.LPStr)] string priorities, out IntPtr err_pos);
 
 		public static int GnuTlsSetDefaultPriorityAppend(Session sess, string priorities) {
@@ -303,7 +303,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, gnutls_set_default_priority_append(sess.ptr, priorities, out errPos, 0));
 		}
 		// int gnutls_set_default_priority_append (gnutls_session_t session, const char * add_prio, const char ** err_pos, unsigned flags)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_set_default_priority_append")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_set_default_priority_append")]
 		private static extern int gnutls_set_default_priority_append(IntPtr session, [In()][MarshalAs(UnmanagedType.LPStr)] string priorities, out IntPtr err_pos, uint flags);
 
 		public static int GnuTlsDhSetPrimeBits(Session sess, uint bits) {
@@ -313,7 +313,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, gnutls_dh_set_prime_bits(sess.ptr, bits));
 		}
 		// void gnutls_dh_set_prime_bits (gnutls_session_t session, unsigned int bits)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_dh_set_prime_bits")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_dh_set_prime_bits")]
 		private static extern int gnutls_dh_set_prime_bits(IntPtr session, uint bits);
 
 		// Transport
@@ -325,7 +325,7 @@ namespace FluentFTP.GnuTLS.Core {
 			gnutls_transport_set_ptr(sess.ptr, socketDescriptor);
 		}
 		// void gnutls_transport_set_ptr (gnutls_session_t session, gnutls_transport_ptr_t fd) (= void * fd)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_transport_set_ptr")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_transport_set_ptr")]
 		private static extern void gnutls_transport_set_ptr(IntPtr session, IntPtr fd);
 
 		public static void GnuTlsTransportSetInt2(Session sess, int socketDescriptorRecv, int socketDescriptorSend) {
@@ -335,15 +335,15 @@ namespace FluentFTP.GnuTLS.Core {
 			gnutls_transport_set_int2(sess.ptr, socketDescriptorRecv, socketDescriptorSend);
 		}
 		// void gnutls_transport_set_int (gnutls_session_t session, int recv_fd, int send_fd)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_transport_set_int2")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_transport_set_int2")]
 		private static extern void gnutls_transport_set_int2(IntPtr session, int recv_fd, int send_fd);
 
 		// ssize_t gnutls_record_recv (gnutls_session_t session, void * data, size_t data_size)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_record_recv")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_record_recv")]
 		internal static extern int gnutls_record_recv(IntPtr session, [Out()][MarshalAs(UnmanagedType.LPArray, SizeConst = 2048)] byte[] data, int data_size);
 
 		// ssize_t gnutls_record_send (gnutls_session_t session, const void * data, size_t data_size)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_record_send")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_record_send")]
 		internal static extern int gnutls_record_send(IntPtr session, [In()][MarshalAs(UnmanagedType.LPArray, SizeConst = 2048)] byte[] data, int data_size);
 
 		// Session Resume
@@ -352,7 +352,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_session_is_resumed(sess.ptr);
 		}
 		// int gnutls_session_is_resumed (gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_is_resumed")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_is_resumed")]
 		private static extern bool gnutls_session_is_resumed(IntPtr session);
 
 		public static int GnuTlsSessionGetData2(Session sess, out DatumT data) {
@@ -369,7 +369,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, gnutls_session_get_data2(sess, out data));
 		}
 		// int gnutls_session_get_data2 (gnutls_session_t session, gnutls_datum_t * data)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_get_data2")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_get_data2")]
 		private static extern int gnutls_session_get_data2(IntPtr session, out DatumT data);
 
 		public static int GnuTlsSessionSetData(Session sess, DatumT data) {
@@ -386,11 +386,11 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, gnutls_session_set_data(sess, data.ptr, data.size));
 		}
 		// int gnutls_session_set_data (gnutls_session_t session, const void * session_data, size_t session_data_size)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_set_data")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_set_data")]
 		private static extern int gnutls_session_set_data(IntPtr session, IntPtr session_data, ulong session_data_size);
 
 		// const gnutls_datum_t* gnutls_certificate_get_peers (gnutls_session_t session, unsigned int * list_size)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_get_peers")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_get_peers")]
 		private static extern IntPtr gnutls_certificate_get_peers(IntPtr session, IntPtr session_data, uint list_size);
 
 		public static SessionFlagsT GnuTlsSessionGetFlags(Session sess) {
@@ -407,7 +407,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_session_get_flags(sess);
 		}
 		// unsigned gnutls_session_get_flags(gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_get_flags")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_session_get_flags")]
 		private static extern SessionFlagsT gnutls_session_get_flags(IntPtr session);
 
 
@@ -430,7 +430,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return result;
 		}
 		// int gnutls_alpn_set_protocols (gnutls_session_t session, const gnutls_datum_t * protocols, unsigned protocols_size, unsigned int flags)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_alpn_set_protocols")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_alpn_set_protocols")]
 		private static extern int gnutls_alpn_set_protocols(IntPtr session, IntPtr protocols, int protocols_size, AlpnFlagsT flags);
 
 		public static string GnuTlsAlpnGetSelectedProtocol(Session sess) {
@@ -442,7 +442,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return Marshal.PtrToStringAnsi(data.ptr);
 		}
 		// int gnutls_alpn_get_selected_protocol (gnutls_session_t session, gnutls_datum_t * protocol)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_alpn_get_selected_protocol")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_alpn_get_selected_protocol")]
 		private static extern int gnutls_alpn_get_selected_protocol(IntPtr session, DatumT data);
 
 
@@ -451,11 +451,11 @@ namespace FluentFTP.GnuTLS.Core {
 		// G N U T L S API calls for certificate credentials init / deinit
 
 		// int gnutls_certificate_allocate_credentials (gnutls_certificate_credentials_t * res)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_allocate_credentials")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_allocate_credentials")]
 		public static extern int gnutls_certificate_allocate_credentials(ref IntPtr res);
 
 		// void gnutls_certificate_free_credentials(gnutls_certificate_credentials_t sc)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_free_credentials")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_free_credentials")]
 		public static extern void gnutls_certificate_free_credentials(IntPtr sc);
 
 		// Set
@@ -467,7 +467,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, gnutls_credentials_set(sess.ptr, CredentialsTypeT.GNUTLS_CRD_CERTIFICATE, cred.ptr));
 		}
 		// int gnutls_credentials_set (gnutls_session_t session, gnutls_credentials_type_t type, void * cred)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_credentials_set")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_credentials_set")]
 		private static extern int gnutls_credentials_set(IntPtr session, CredentialsTypeT type, IntPtr cred);
 
 		// Info
@@ -479,7 +479,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_certificate_client_get_request_status(sess.ptr);
 		}
 		// unsigned gnutls_certificate_client_get_request_status(gnutls_session_t session)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_client_get_request_status")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_client_get_request_status")]
 		private static extern bool gnutls_certificate_client_get_request_status(IntPtr session);
 
 		// C e r t i f i c a t e  V e r i f i c a t i o n
@@ -494,7 +494,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return GnuUtils.Check(gcm, result);
 		}
 		// int gnutls_certificate_verify_peers3 (gnutls_session_t session, const char * hostname, unsigned int * status)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_verify_peers3")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_verify_peers3")]
 		private static extern int gnutls_certificate_verify_peers3(IntPtr session, [In()][MarshalAs(UnmanagedType.LPStr)] string hostname, [Out()][MarshalAs(UnmanagedType.U4)] out CertificateStatusT status);
 
 		public static void GnuTlsCertificateSetVerifyFlags(CertificateCredentials res, CertificateVerifyFlagsT flags) {
@@ -505,7 +505,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return;
 		}
 		// void gnutls_certificate_set_verify_flags(gnutls_certificate_credentials_t res, unsigned int flags)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_set_verify_flags")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_set_verify_flags")]
 		private static extern void gnutls_certificate_set_verify_flags(IntPtr res, CertificateVerifyFlagsT flags);
 
 		public static CertificateTypeT GnuTlsCertificateTypeGet2(Session sess, CtypeTargetT target) {
@@ -515,7 +515,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_certificate_type_get2(sess.ptr, target);
 		}
 		// gnutls_certificate_type_t gnutls_certificate_type_get2 (gnutls_session_t session, gnutls_ctype_target_t target)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_type_get2")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_type_get2")]
 		private static extern CertificateTypeT gnutls_certificate_type_get2(IntPtr session, CtypeTargetT target);
 
 		// Retrieve certificate(s)
@@ -541,7 +541,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return temp;
 		}
 		// const gnutls_datum_t * gnutls_certificate_get_peers (gnutls_session_t session, unsigned int * list_size)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_get_peers")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_certificate_get_peers")]
 		private static extern IntPtr gnutls_certificate_get_peers(IntPtr session, ref uint list_size);
 
 
@@ -554,7 +554,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_x509_crt_init(ref cert);
 		}
 		//  int gnutls_x509_crt_init (gnutls_x509_crt_t * cert)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_init")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_init")]
 		private static extern int gnutls_x509_crt_init(ref IntPtr cert);
 
 		public static int GnuTlsX509CrtDeinit(IntPtr cert) {
@@ -564,7 +564,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_x509_crt_deinit(cert);
 		}
 		//  int gnutls_x509_crt_deinit (gnutls_x509_crt_t * cert)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_deinit")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_deinit")]
 		private static extern int gnutls_x509_crt_deinit(IntPtr cert);
 
 		public static int GnuTlsX509CrtImport(IntPtr cert, ref DatumT data, X509CrtFmtT format) {
@@ -574,7 +574,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_x509_crt_import(cert, ref data, format);
 		}
 		// int gnutls_x509_crt_import (gnutls_x509_crt_t cert, const gnutls_datum_t * data, gnutls_x509_crt_fmt_t format)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_import")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_import")]
 		private static extern int gnutls_x509_crt_import(IntPtr cert, ref DatumT data, X509CrtFmtT format);
 
 		public static int GnuTlsX509CrtPrint(IntPtr cert, CertificatePrintFormatsT format, ref DatumT output) {
@@ -584,7 +584,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_x509_crt_print(cert, format, ref output);
 		}
 		//  int gnutls_x509_crt_print (gnutls_x509_crt_t cert, gnutls_certificate_print_formats_t format, gnutls_datum_t * out)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_print")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_print")]
 		private static extern int gnutls_x509_crt_print(IntPtr cert, CertificatePrintFormatsT format, ref DatumT output);
 
 		public static int GnuTlsX509CrtExport2(IntPtr cert, X509CrtFmtT format, ref DatumT output) {
@@ -594,7 +594,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_x509_crt_export2(cert, format, ref output);
 		}
 		// int gnutls_x509_crt_export2(gnutls_x509_crt_t cert, gnutls_x509_crt_fmt_t format, gnutls_datum_t* out)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_export2")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_x509_crt_export2")]
 		private static extern int gnutls_x509_crt_export2(IntPtr cert, X509CrtFmtT format, ref DatumT output);
 
 		public static int GnuTlsPcertImportRawpkRaw(IntPtr pcert, ref DatumT data, X509CrtFmtT format, uint keyUsage, uint flags) {
@@ -604,7 +604,7 @@ namespace FluentFTP.GnuTLS.Core {
 			return gnutls_pcert_import_rawpk_raw(pcert, ref data, format, keyUsage, flags);
 		}
 		//  int gnutls_pcert_import_rawpk_raw (gnutls_pcert_st* pcert, const gnutls_datum_t* rawpubkey, gnutls_x509_crt_fmt_t format, unsigned int key_usage, unsigned int flags)
-		[DllImport("Libs/libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_pcert_import_rawpk_raw")]
+		[DllImport("libgnutls-30.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint = "gnutls_pcert_import_rawpk_raw")]
 		private static extern int gnutls_pcert_import_rawpk_raw(IntPtr pcert, ref DatumT data, X509CrtFmtT format, uint key_usage, uint flags);
 
 	}

--- a/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
@@ -82,7 +82,7 @@ namespace FluentFTP.GnuTLS {
 		// * re-used, therefore static
 		private static DatumT resumeDataTLS = new();
 
-		// Handle for Libs/gnutls-30.dll
+		// Handle for gnutls-30.dll
 		internal static IntPtr hDLL = IntPtr.Zero;
 
 		//


### PR DESCRIPTION
Since .NET Framework does not support relative path names in the DllImport file name (as opposed to .NET 6, for example), using a subfolder for the GnuTLS .dll files make life difficult.

In order to avoid conditional compilation based on the target (because the DllImport filename must be a compile time constant string), let's do away with the relative path and simply place the .dll files in the same folder as the .exe file.

This also avoids having to use conditionals in the .csproj file to make copy to output use the right destination for the .dll files, depending on selected target.

Much easier to avoid this hassle and place the .dll files in the same directory as the .exe file, this is where all the microsoft .dll go as well, so there is "precedent" in doing it this way.