### PR TITLE
Packaging for both packages.config AND PackageReference types

### DIFF
--- a/FluentFTP.GnuTLS/FluentFTP.GnuTLS.csproj
+++ b/FluentFTP.GnuTLS/FluentFTP.GnuTLS.csproj
@@ -18,13 +18,27 @@
 	</PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>net60;net50;net472;net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+
+	<TargetFrameworks>net60;net50;net472;net462;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>10.0</LangVersion>
         <RepositoryUrl>https://github.com/robinrodricks/FluentFTP</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
+
 	<ContentTargetFolders>contentFiles</ContentTargetFolders>
+	<!--
+	    default: content;contentFiles
+	    Projects using packages.config use the contents directory
+		The will be copied to the wrong place on build, so don't help for .dll files
+	    Projects using PackageReference use the contentFiles directory.
+		These will be then copied to the folder location of the exe file on build.
+	-->
+
     </PropertyGroup>
 
+    <!--
+        This copies the .dll files to the respective targetframework folders into
+	the root location where the main executable resides.
+    -->
     <ItemGroup>
         <ContentWithTargetPath Include="Libs\Win64\**">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -32,25 +46,52 @@
         </ContentWithTargetPath>
     </ItemGroup>
 
-    <PropertyGroup>
-        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);GetMyGnuTLSDlls</TargetsForTfmSpecificBuildOutput>
-    </PropertyGroup>
- 
-    <Target Name="GetMyGnuTLSDlls">
-        <ItemGroup>
-            <BuildOutputInPackage Include="Libs\Win64\**">
-            </BuildOutputInPackage>
-        </ItemGroup>
-    </Target>
+    <!--
+        This copies the .dll files to the package contentFiles folders
+	(see comment for ContentTargetFolders above).
+    -->
+    <ItemGroup>
+	<Content Include="Libs\Win64\**">
+	</Content>
+    </ItemGroup>
+
+    <!--
+        This copies the .dll files to the package lib folders for packages.config projects,
+	but without the path. This allows the FluentFTP.GnuTLS.targets file to remain constant
+	(see comment for ContentTargetFolders above).
+    -->
+    <ItemGroup>
+        <None Include="Libs\Win64\**">
+            <Pack>True</Pack>
+            <PackagePath>\content\%(Filename)%(Extension)</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <!--
+	This magic causes MSBUILD on the install machine to copy in the .dlls on a build
+	We are moving a .target file (which contains the copy command) to the nuget package
+    -->
+    <ItemGroup>
+        <Content Include="Libs\Helpers\FluentFTP.GnuTLS.targets">
+            <Pack>True</Pack>
+           <PackagePath>build/FluentFTP.GnuTLS.targets</PackagePath>
+        </Content>
+    </ItemGroup>
 
     <ItemGroup>
+        <!--
+            Logo file -> package
+        -->
         <None Include="..\.github\logo-nuget.png">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>
-        <None Include="..\LICENSE">
+        <!--
+            License file -> package
+        -->
+	<None Include="..\LICENSE">
             <Pack>True</Pack>
-            <PackagePath></PackagePath>
+            <PackagePath>\</PackagePath>
         </None>
     </ItemGroup>
     

--- a/FluentFTP.GnuTLS/FluentFTP.GnuTLS.csproj
+++ b/FluentFTP.GnuTLS/FluentFTP.GnuTLS.csproj
@@ -27,15 +27,17 @@
 	<ContentTargetFolders>contentFiles</ContentTargetFolders>
 	<!--
 	    default: content;contentFiles
-	    Projects using packages.config use the contents directory
-		The will be copied to the wrong place on build, so don't help for .dll files
-	    Projects using PackageReference use the contentFiles directory.
+	    Projects using packages.config use the "contents" directory
+		These will be copied to the wrong place on build, so doesn't help for .dll files
+		and anyway it also refuses to reference foreign dll files correctly.
+	    Projects using PackageReference use the "contentFiles" directory.
 		These will be then copied to the folder location of the exe file on build.
 	-->
 
     </PropertyGroup>
 
     <!--
+	Build output folder:
         This copies the .dll files to the respective targetframework folders into
 	the root location where the main executable resides.
     -->
@@ -47,7 +49,8 @@
     </ItemGroup>
 
     <!--
-        This copies the .dll files to the package contentFiles folders
+	Nuget folder:
+	This copies the .dll files to the package "contentFiles" folders
 	(see comment for ContentTargetFolders above).
     -->
     <ItemGroup>
@@ -56,7 +59,8 @@
     </ItemGroup>
 
     <!--
-        This copies the .dll files to the package lib folders for packages.config projects,
+	Nuget folder:
+        This copies the .dll files to the package "content" folder for packages.config projects,
 	but without the path. This allows the FluentFTP.GnuTLS.targets file to remain constant
 	(see comment for ContentTargetFolders above).
     -->
@@ -68,8 +72,10 @@
     </ItemGroup>
 
     <!--
-	This magic causes MSBUILD on the install machine to copy in the .dlls on a build
+	Nuget folder:
+	This magic causes MSBUILD on the install machine to copy in the .dlls on a build.
 	We are moving a .target file (which contains the copy command) to the nuget package
+	build folder. The copy command will move the .dll files to the build output folder.
     -->
     <ItemGroup>
         <Content Include="Libs\Helpers\FluentFTP.GnuTLS.targets">
@@ -80,6 +86,7 @@
 
     <ItemGroup>
         <!--
+            Nuget folder:
             Logo file -> package
         -->
         <None Include="..\.github\logo-nuget.png">
@@ -87,6 +94,7 @@
             <PackagePath>\</PackagePath>
         </None>
         <!--
+            Nuget folder:
             License file -> package
         -->
 	<None Include="..\LICENSE">

--- a/FluentFTP.GnuTLS/Libs/Helpers/FluentFTP.GnuTLS.targets
+++ b/FluentFTP.GnuTLS/Libs/Helpers/FluentFTP.GnuTLS.targets
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <Files Include="$(MSBuildThisFileDirectory)/../content/*.dll" />
+  </ItemGroup>
+  <Target Name="CopyFiles" AfterTargets="Build">
+    <Copy SourceFiles="@(Files)" DestinationFolder="$(TargetDir)" />
+  </Target>
+</Project>


### PR DESCRIPTION
No problem at all:
Projects using **PackageReference** use the "contentFiles" directory. These files will be then copied to the folder location of the exe file on build by MSBuild all by itself, the folder structure is not a problem.

Problem:
Projects using **packages.config** use the "contents" directory. These will be copied to the wrong place on nuget install, ignored on build, so they are not found on run. If you force them in to the right location in the package, Nuget refuses to reference these "foreign dll files" correctly. The install of the package fails.

Solution:
Add a MSBuild .target file that will copy in the .dll files on build to make sure they are always present.