### PR TITLE
Don't cache gnutls_free HDL - it sometimes changes

### DIFF
--- a/FluentFTP.GnuTLS/FluentFTP.GnuTLS.csproj
+++ b/FluentFTP.GnuTLS/FluentFTP.GnuTLS.csproj
@@ -11,7 +11,7 @@
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FluentFTP.GnuTLS.xml</DocumentationFile>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
-		<Version>1.0.5</Version>
+		<Version>1.0.6</Version>
 		<PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>
 		<PackageIcon>logo-nuget.png</PackageIcon>
 		<LangVersion>10.0</LangVersion>

--- a/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
@@ -110,6 +110,9 @@ namespace FluentFTP.GnuTLS {
 			htimeout = handshakeTimeout;
 			ptimeout = pollTimeout;
 
+			// Cached handle for gnutls_free only valid for life of this GnuTlsStream
+			hDLL = IntPtr.Zero;
+
 			if (ctorCount < 1) {
 
 				// On the first instance of GnuTlsStream, setup:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+#### 1.0.6
+ - HotFix: AccessViolation exception due to cached gnutls_free handle.
+
 #### 1.0.5
  - Package: Multitarget: `net50`, `net60`, `net462`, `net472`, `netstandard2.0`, `netstandard2.1`
  - Package: Prepare for Win/Linux/64bit/32bit: change paths and copy-to-output handling again


### PR DESCRIPTION
**Hot fix**: Multiple connects/disconnects **can** fail after some time because the cached value for the gnutls_free handle suddenly changes due to GC memory being rearranged.