### PR TITLE
Further safety on cached .dll load address handle

### DIFF
--- a/FluentFTP.GnuTLS/Core/GnuTls.cs
+++ b/FluentFTP.GnuTLS/Core/GnuTls.cs
@@ -63,11 +63,9 @@ namespace FluentFTP.GnuTLS.Core {
 		delegate void freeFuncDelegate(IntPtr ptr);
 
 		public static void GnuTlsFree(IntPtr ptr) {
+			GnuTlsInternalStream.hDLL = LoadLibrary("libgnutls-30.dll");
 			if (GnuTlsInternalStream.hDLL == IntPtr.Zero) {
-				GnuTlsInternalStream.hDLL = LoadLibrary("libgnutls-30.dll");
-				if (GnuTlsInternalStream.hDLL == IntPtr.Zero) {
-					throw new GnuTlsException("LoadLibrary for libgnutls-30.dll failed.");
-				}
+				throw new GnuTlsException("LoadLibrary for libgnutls-30.dll failed.");
 			}
 
 			IntPtr freeFuncExpPtr = (IntPtr)GetProcAddress(GnuTlsInternalStream.hDLL, "gnutls_free");

--- a/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
@@ -110,9 +110,6 @@ namespace FluentFTP.GnuTLS {
 			htimeout = handshakeTimeout;
 			ptimeout = pollTimeout;
 
-			// Cached handle for gnutls_free only valid for life of this GnuTlsStream
-			hDLL = IntPtr.Zero;
-
 			if (ctorCount < 1) {
 
 				// On the first instance of GnuTlsStream, setup:


### PR DESCRIPTION
Discovered when testing on .NET Framework 4.6.2
Looks like it is safest to reload the .dll handle each time it is needed. 