### PR TITLE
Windows + Linux: Fix bug - is unix string length

### DIFF
--- a/FluentFTP.GnuTLS/Core/GnuTls.cs
+++ b/FluentFTP.GnuTLS/Core/GnuTls.cs
@@ -387,7 +387,7 @@ namespace FluentFTP.GnuTLS.Core {
 			var datumPtr = Marshal.AllocHGlobal(Marshal.SizeOf<DatumT>());
 			var valuePtr = Marshal.StringToHGlobalAnsi(protocols);
 
-			Marshal.StructureToPtr(new DatumT { ptr = valuePtr, size = (uint)protocols.Length }, datumPtr, true);
+			Marshal.StructureToPtr(new DatumT { ptr = valuePtr, size = (uint)protocols.Length + 1 }, datumPtr, true);
 
 			int result = GnuUtils.Check(gcm, linux ?
 				GnuTlsLin.gnutls_alpn_set_protocols(sess.ptr, datumPtr, 1, AlpnFlagsT.GNUTLS_ALPN_MANDATORY) :


### PR DESCRIPTION
This never posed in issue when running under Windows (why, oh why?), but under Linux, the unmanaged data's length being reported to one byte shorter than actually overwritten caused very frequent random crashes.

Always read the docs: 

`Marshal.PtrToStringAnsi`

This method copies embedded null characters, **and includes a terminating null character.**