### PR TITLE
LoadLibraryDllPathPrefix

### DIFF
--- a/FluentFTP.GnuTLS/Core/GnuTls.cs
+++ b/FluentFTP.GnuTLS/Core/GnuTls.cs
@@ -110,7 +110,7 @@ namespace FluentFTP.GnuTLS.Core {
 			// Static class construction, used to initialize the entry point addresses of the HANDLERs
 			// that are defined as properties in this class.
 
-			// LoadAllFunctions();
+			// LoadAllFunctions(); Most of the (Global)Init functions will do this now.
 		}
 
 		internal static void SetLoadLibraryDllNamePrefix(string pfx) {

--- a/FluentFTP.GnuTLS/Core/GnuTls.cs
+++ b/FluentFTP.GnuTLS/Core/GnuTls.cs
@@ -8,10 +8,10 @@ namespace FluentFTP.GnuTLS.Core {
 
 		public static bool platformIsLinux;
 
-		private static IntPtr hModule = IntPtr.Zero;
+		public static string loadLibraryDllNamePrefix = string.Empty;
 
 		#region FunctionLoader
-
+		private static IntPtr hModule = IntPtr.Zero;
 		private static bool functionsAreLoaded = false;
 
 		private static class FunctionLoader {
@@ -110,7 +110,11 @@ namespace FluentFTP.GnuTLS.Core {
 			// Static class construction, used to initialize the entry point addresses of the HANDLERs
 			// that are defined as properties in this class.
 
-			LoadAllFunctions();
+			// LoadAllFunctions();
+		}
+
+		internal static void SetLoadLibraryDllNamePrefix(string pfx) {
+			loadLibraryDllNamePrefix = pfx;
 		}
 
 		private static void LoadAllFunctions() {
@@ -135,7 +139,7 @@ namespace FluentFTP.GnuTLS.Core {
 
 			// Initialize the function loader
 
-			FunctionLoader.Load(useDllName);
+			FunctionLoader.Load(loadLibraryDllNamePrefix + useDllName);
 
 			// Get all the needed functions from the library into handlers via delegates.
 			// In this section of the code:
@@ -241,6 +245,8 @@ namespace FluentFTP.GnuTLS.Core {
 		delegate void gnutls_global_set_log_function_([In()][MarshalAs(UnmanagedType.FunctionPtr)] Logging.GnuTlsLogCBFunc log_func);
 		static gnutls_global_set_log_function_ gnutls_global_set_log_function_h;
 		public static void GnuTlsGlobalSetLogFunction(Logging.GnuTlsLogCBFunc logCBFunc) {
+			if (!functionsAreLoaded) LoadAllFunctions();
+
 			string gcm = GnuUtils.GetCurrentMethod();
 			Logging.LogGnuFunc(gcm);
 

--- a/FluentFTP.GnuTLS/GnuConfig.cs
+++ b/FluentFTP.GnuTLS/GnuConfig.cs
@@ -38,6 +38,12 @@ namespace FluentFTP.GnuTLS {
 		public string SetALPNDataConnection { get; set; } = "ftp-data";
 
 		/// <summary>
+		/// Add an optional string prefix to the LoadLibrary dllname
+		/// </summary>
+
+		public string LoadLibraryDllNamePrefix = string.Empty;
+
+		/// <summary>
 		/// Normally, the GnuTLS library is de-initialised after dispose of the control
 		/// connection. If you plan to use the GnuTLS library functions in a multithreaded
 		/// environment, you need to disable this behaviour by setting this to false. The

--- a/FluentFTP.GnuTLS/GnuTlsStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream.cs
@@ -50,6 +50,7 @@ namespace FluentFTP.GnuTLS {
 				isControl ? null : (controlConnStream as GnuTlsStream).BaseStream,
 				priority,
 				config.DeInitGnuTls,
+				config.LoadLibraryDllNamePrefix,
 				config.HandshakeTimeout,
 				config.PollTimeout,
 				fluentFtpLog,

--- a/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
@@ -96,6 +96,7 @@ namespace FluentFTP.GnuTLS {
 			GnuTlsInternalStream streamToResumeFrom,
 			string priorityString,
 			bool deInitGnuTls,
+			string loadLibraryDllNamePrefix,
 			int handshakeTimeout,
 			int pollTimeout,
 			GnuStreamLogCBFunc elog,
@@ -107,6 +108,7 @@ namespace FluentFTP.GnuTLS {
 			alpn = alpnString;
 			priority = priorityString;
 			deInit = deInitGnuTls;
+			GnuTls.SetLoadLibraryDllNamePrefix(loadLibraryDllNamePrefix);
 			hostname = targetHostString;
 			htimeout = handshakeTimeout;
 			ptimeout = pollTimeout;


### PR DESCRIPTION
See #76 

Provide a new config parameter to aid in (seldom) seen packaging szenarios.

```cs
		/// <summary>
		/// Add an optional string prefix to the LoadLibrary dllname
		/// </summary>

		public string LoadLibraryDllNamePrefix = string.Empty;

```