### PR TITLE
Fix access violation when using multiple async clients

### DIFF
--- a/FluentFTP.GnuTLS/Core/Credentials.cs
+++ b/FluentFTP.GnuTLS/Core/Credentials.cs
@@ -11,7 +11,7 @@ namespace FluentFTP.GnuTLS.Core {
 			credentialsType = type;
 		}
 
-		public void Dispose() {
+		public virtual void Dispose() {
 		}
 	}
 
@@ -34,7 +34,7 @@ namespace FluentFTP.GnuTLS.Core {
 			_ = GnuUtils.Check("*GnuTlsCertificateAllocateCredentials(...)", GnuTls.GnuTlsCertificateAllocateCredentials(ref ptr));
 		}
 
-		public void Dispose() {
+		public override void Dispose() {
 			if (ptr != IntPtr.Zero) {
 				string gcm = GnuUtils.GetCurrentMethod() + ":CertificateCredentials";
 				Logging.LogGnuFunc(gcm);
@@ -42,6 +42,7 @@ namespace FluentFTP.GnuTLS.Core {
 				GnuTls.GnuTlsCertificateFreeCredentials(ptr);
 				ptr = IntPtr.Zero;
 			}
+			base.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
Related to #88

The GnuTls wrapper always freed the dynamic library when deinit was called, even if init was called multiple times. This would only work if clients are created and disposed strictly sequentially. I added a use count to keep track of the number of active users and only free the library if none are left. There are also other improvements to thread safety and shadowed Dispose() methods.

There is also a new test case to check for crashes with parallel connections.