### PR TITLE
Bring in DllUnloadByUseCount config variable

### DIFF
--- a/FluentFTP.GnuTLS/Core/GnuTls.cs
+++ b/FluentFTP.GnuTLS/Core/GnuTls.cs
@@ -260,6 +260,9 @@ namespace FluentFTP.GnuTLS.Core {
 		public static string GnuTlsCheckVersion(string reqVersion) {
 			LoadAllFunctions(false);
 
+			string gcm = GnuUtils.GetCurrentMethod();
+			Logging.LogGnuFunc(gcm);
+
 			IntPtr versionPtr = gnutls_check_version_h(reqVersion);
 			string version = Marshal.PtrToStringAnsi(versionPtr);
 			// gnutls_free_h(versionPtr);
@@ -272,8 +275,6 @@ namespace FluentFTP.GnuTLS.Core {
 		delegate void gnutls_global_set_log_function_([In()][MarshalAs(UnmanagedType.FunctionPtr)] Logging.GnuTlsLogCBFunc log_func);
 		static gnutls_global_set_log_function_ gnutls_global_set_log_function_h;
 		public static void GnuTlsGlobalSetLogFunction(Logging.GnuTlsLogCBFunc logCBFunc) {
-			LoadAllFunctions(false);
-
 			string gcm = GnuUtils.GetCurrentMethod();
 			Logging.LogGnuFunc(gcm);
 

--- a/FluentFTP.GnuTLS/Core/GnuTls.cs
+++ b/FluentFTP.GnuTLS/Core/GnuTls.cs
@@ -105,10 +105,10 @@ namespace FluentFTP.GnuTLS.Core {
 				return Marshal.GetDelegateForFunctionPointer(pFunc, typeof(T));
 			}
 
-			public static bool Free() {
+			public static bool Free(bool dllUnload) {
 				lock (loaderLock) {
 					--useCount;
-					if (useCount == 0) {
+					if (useCount == 0 && dllUnload) {
 						_ = platformIsLinux ? dlclose(hModule) == 1 : FreeLibrary(hModule);
 						functionsAreLoaded = false;
 					}
@@ -308,13 +308,13 @@ namespace FluentFTP.GnuTLS.Core {
 		static gnutls_global_deinit_ gnutls_global_deinit_h;
 		// Calls deinit and unloads the library if no users are left
 		// Returns true if this was the final user
-		public static bool GnuTlsGlobalDeInit() {
+		public static bool GnuTlsGlobalDeInit(bool dllUnload) {
 			string gcm = GnuUtils.GetCurrentMethod();
 			Logging.LogGnuFunc(gcm);
 
 			gnutls_global_deinit_h();
 
-			return FunctionLoader.Free();
+			return FunctionLoader.Free(dllUnload);
 		}
 
 		// void gnutls_free(* ptr)

--- a/FluentFTP.GnuTLS/GnuConfig.cs
+++ b/FluentFTP.GnuTLS/GnuConfig.cs
@@ -40,8 +40,17 @@ namespace FluentFTP.GnuTLS {
 		/// <summary>
 		/// Add an optional string prefix to the LoadLibrary dllname
 		/// </summary>
-
 		public string LoadLibraryDllNamePrefix = string.Empty;
+
+		/// <summary>
+		/// The FluentFTP.GnuTLS extension to FluentFTP will correctly handle multi-threaded
+		/// concurrent operation by maintining a "use-count", just like the underlying GnuTLS
+		/// library does. This use-count is checked on dispose of the GnuTlsStream and an unload
+		/// of the GnuTls library .dlls only takes place when this value is zero.
+		/// To disable unloading and to keep the libraries permanently loaded, set
+		/// DllUnloadByUseCount to false.
+		/// </summary>
+		public bool DllUnloadByUseCount { get; set; } = true;
 
 		/// <summary>
 		/// How long to wait for a handshake before giving up, in milliseconds.

--- a/FluentFTP.GnuTLS/GnuTlsStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream.cs
@@ -50,6 +50,7 @@ namespace FluentFTP.GnuTLS {
 				isControl ? null : (controlConnStream as GnuTlsStream).BaseStream,
 				priority,
 				config.LoadLibraryDllNamePrefix,
+				config.DllUnloadByUseCount,
 				config.HandshakeTimeout,
 				config.PollTimeout,
 				fluentFtpLog,

--- a/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
@@ -208,7 +208,9 @@ namespace FluentFTP.GnuTLS {
 					// On destructing this instance, de-init the library
 					// Note: The internal logic of this handles loading/unloading the library etc.
 
-					weAreInitialized = !GnuTls.GnuTlsGlobalDeInit(dllUnload);
+					if (dllUnload) {
+						weAreInitialized = !GnuTls.GnuTlsGlobalDeInit();
+					}
 				}
 			}
 

--- a/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
+++ b/FluentFTP.GnuTLS/GnuTlsStream/GnuTlsInternalStream.cs
@@ -67,6 +67,8 @@ namespace FluentFTP.GnuTLS {
 
 		private bool weAreControlConnection = true;
 
+		private bool dllUnload = true;
+
 		//
 
 		// The TLS session associated with this GnuTlsStream
@@ -94,6 +96,7 @@ namespace FluentFTP.GnuTLS {
 			GnuTlsInternalStream streamToResumeFrom,
 			string priorityString,
 			string loadLibraryDllNamePrefix,
+			bool dllUnloadByUseCount,
 			int handshakeTimeout,
 			int pollTimeout,
 			GnuStreamLogCBFunc elog,
@@ -105,6 +108,7 @@ namespace FluentFTP.GnuTLS {
 			alpn = alpnString;
 			priority = priorityString;
 			GnuTls.SetLoadLibraryDllNamePrefix(loadLibraryDllNamePrefix);
+			dllUnload = dllUnloadByUseCount;
 			hostname = targetHostString;
 			htimeout = handshakeTimeout;
 			ptimeout = pollTimeout;
@@ -204,7 +208,7 @@ namespace FluentFTP.GnuTLS {
 					// On destructing this instance, de-init the library
 					// Note: The internal logic of this handles loading/unloading the library etc.
 
-					weAreInitialized = !GnuTls.GnuTlsGlobalDeInit();
+					weAreInitialized = !GnuTls.GnuTlsGlobalDeInit(dllUnload);
 				}
 			}
 


### PR DESCRIPTION
```cs
/// <summary>
/// The FluentFTP.GnuTLS extension to FluentFTP will correctly handle multi-threaded
/// concurrent operation by maintining a "use-count", just like the underlying GnuTLS
/// library does. This use-count is checked on dispose of the GnuTlsStream and an unload
/// of the GnuTls library .dlls only takes place when this value is zero.
/// To disable unloading and to keep the libraries permanently loaded, set
/// DllUnloadByUseCount to false.
/// </summary>
public bool DllUnloadByUseCount { get; set; } = true;
```

See #88 and https://github.com/robinrodricks/FluentFTP.GnuTLS/issues/88#issuecomment-1646167745