### PR TITLE
Suppress PUSH error on GnuTls_Bye at Dispose

### DIFF
--- a/FluentFTP.GnuTLS/Core/GnuTls.cs
+++ b/FluentFTP.GnuTLS/Core/GnuTls.cs
@@ -618,7 +618,7 @@ namespace FluentFTP.GnuTLS.Core {
 
 			stopWatch.Stop();
 
-			return GnuUtils.Check(gcm, result);
+			return GnuUtils.Check(gcm, result, new int[] { -53 });
 		}
 
 		// void gnutls_handshake_set_timeout (gnutls_session_t session, unsigned int ms)


### PR DESCRIPTION
Happens on Dispose of stream with stalled socket. No need to raise exception in this case.